### PR TITLE
Update to examples link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ This is easily achieved by downloading
 Usage Example
 =============
 
-see examples in githup repository: https://github.com/adafruit/Adafruit_CircuitPython_STMPE610/exmaples
+See examples in githup repository: https://github.com/adafruit/Adafruit_CircuitPython_STMPE610/tree/master/examples
+
 Contributing
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ This is easily achieved by downloading
 Usage Example
 =============
 
-See examples in githup repository: https://github.com/adafruit/Adafruit_CircuitPython_STMPE610/tree/master/examples
+See examples in github repository: https://github.com/adafruit/Adafruit_CircuitPython_STMPE610/tree/master/examples
 
 Contributing
 ============


### PR DESCRIPTION
Found a typo in the URL for the examples that led to a dead-end.  Updated to: 
https://github.com/adafruit/Adafruit_CircuitPython_STMPE610/tree/master/examples.  Don't know if this is the proper URL to use, but that's what I get if I traverse to the examples from the main repo page.