### PR TITLE
Fix error in formatting RuntimeError string.

### DIFF
--- a/adafruit_stmpe610.py
+++ b/adafruit_stmpe610.py
@@ -471,7 +471,6 @@ class Adafruit_STMPE610_SPI(Adafruit_STMPE610):
                 raise RuntimeError(
                     f"Failed to find STMPE610 controller! Chip Version {hex(version).upper()}. "
                     "If you are using the breakout, verify you are in SPI mode."
-                    % version
                 )
         super().__init__()
 


### PR DESCRIPTION
Before you got:
```
TypeError: not all arguments converted during string formatting
```

Now you get:
```
RuntimeError: Failed to find STMPE610 controller! Chip Version 0XFFFF. If you are using the breakout, verify you are in SPI mode.
```